### PR TITLE
fix: use the .cmd NDK clangs on Windows

### DIFF
--- a/native_toolchain_rs/lib/src/build_environment.dart
+++ b/native_toolchain_rs/lib/src/build_environment.dart
@@ -48,7 +48,10 @@ interface class AndroidBuildEnvironmentFactory {
       final compilerBinariesDir = path.dirname(
         path.fromUri(cCompiler.compiler),
       );
-      final binaryPath = path.join(compilerBinariesDir, binaryName);
+      final binaryPath = path.join(
+        compilerBinariesDir,
+        (OS.current == OS.windows) ? '$binaryName.cmd' : binaryName,
+      );
 
       if (!File(binaryPath).existsSync()) {
         throw RustValidationException([


### PR DESCRIPTION
Fixes #21